### PR TITLE
[es] Adds azure-pipeline job for building spanish translation

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -7,6 +7,16 @@ jobs:
     steps:
       - script: cd docs/locale/pt_BR && tox -edocs
         displayName: Build Documentation
-      - publish: 'docs/locale/pt_BR/_build/html'
+      - publish: "docs/locale/pt_BR/_build/html"
         displayName: Publish Documentation Artifacts
 
+  - job: es
+    pool:
+      vmImage: ubuntu-18.04
+    container:
+      image: n42org/tox:3.4.0
+    steps:
+      - script: cd docs/locale/es && tox -e docs
+        displayName: Build Spanish Documentation
+      - publish: "docs/locale/es/_build/html"
+        displayName: Publish Spanish Documentation Artifacts

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
       - publish: "docs/locale/pt_BR/_build/html"
         displayName: Publish Documentation Artifacts
 
-  - job: Build es
+  - job: es
     pool:
       vmImage: ubuntu-18.04
     container:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -7,6 +7,16 @@ jobs:
     steps:
       - script: cd docs/locale/pt_BR && tox -edocs
         displayName: Build Documentation
-      - publish: 'docs/locale/pt_BR/_build/html'
+      - publish: "docs/locale/pt_BR/_build/html"
         displayName: Publish Documentation Artifacts
 
+  - job: Build es
+    pool:
+      vmImage: ubuntu-18.04
+    container:
+      image: n42org/tox:3.4.0
+    steps:
+      - script: cd docs/locale/es && tox -e docs
+        displayName: Build Spanish Documentation
+      - publish: "docs/locale/es/_build/html"
+        displayName: Publish Spanish Documentation Artifacts


### PR DESCRIPTION
Signed-off-by: Claudio Ceballos Paz <claudioceballospaz@MacBook-Air-de-Claudio.local>

Currently, it was supporting only Portuguese. 
This adds the es doc job to the pipeline.

Thanks!