### PR TITLE
第 99 行多了“```”导致格式错乱了

### DIFF
--- a/docs/locale/zh_CN/source/test_network.md
+++ b/docs/locale/zh_CN/source/test_network.md
@@ -96,7 +96,6 @@ Usage:
   network.sh up createChannel -ca -c mychannel -s couchdb -i 2.0.0
   network.sh createChannel -c channelName
   network.sh deployCC -l javascript
-```
 
 From inside the `test-network` directory, run the following command to remove
 any containers or artifacts from any previous runs:


### PR DESCRIPTION
如题