### PR TITLE
[zh_CN][update write_first_app.rst] fix package name typo 

### DIFF
--- a/docs/locale/zh_CN/source/write_first_app.rst
+++ b/docs/locale/zh_CN/source/write_first_app.rst
@@ -61,7 +61,7 @@ In addition to the standard :doc:`prereqs` for Fabric, this tutorial leverages t
 
   .. code:: bash
 
-    sudo apt install build-essentials
+    sudo apt install build-essential
 
 设置区块链网络
 -----------------------------


### PR DESCRIPTION
Package name is build-essential.
It hurt me.