### PR TITLE
[ja_JP] Translate developapps/designelements.rst

### DIFF
--- a/docs/locale/ja_JP/source/developapps/designelements.rst
+++ b/docs/locale/ja_JP/source/developapps/designelements.rst
@@ -1,10 +1,8 @@
 Application design elements
 ===========================
 
-This section elaborates the key features for client application and smart
-contract development found in Hyperledger Fabric. A solid understanding of
-the features will help you design and implement efficient and effective
-solutions.
+この節では、Hyperledger Fabricにおけるクライアントアプリケーションとスマートコントラクトの開発のための重要な機能について述べます。
+これらの機能に対する理解を深めることで、効率的で効果的なソリューションの設計と実装が行えるようになるでしょう。
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This patch translates "Developing Applications >> Application design
elements" (developapps/designelements.rst) into Japanese.

Resolves #218

Signed-off-by: Taku Shimosawa <taku.shimosawa@hal.hitachi.com>