### PR TITLE
[ja_JP] Translate "videos.rst"

### DIFF
--- a/docs/locale/ja_JP/source/videos.rst
+++ b/docs/locale/ja_JP/source/videos.rst
@@ -1,16 +1,14 @@
 Videos
 ======
 
-Refer to the Hyperledger Fabric channel on YouTube
+YouTubeでHyperledger Fabricチャンネルを参照
 
 .. raw:: html
 
    <iframe width="560" height="315" src="https://www.youtube.com/embed/ZgKAahU3FcM?list=PLfuKAwZlKV0_--JYykteXjKyq0GA9j_i1" frameborder="0" allowfullscreen></iframe>
    <br/><br/>
 
-This collection contains developers demonstrating various v1 features and
-components such as: ledger, channels, gossip, SDK, chaincode, MSP, and
-more...
+このコレクションには、台帳、チャネル、ゴシップ、SDK、チェーンコード、MSPなど、さまざまなv1の機能とコンポーネントをデモする開発者が収録されています。
 
 .. Licensed under Creative Commons Attribution 4.0 International License
    https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
This patch translates "Tutorials >> Videos" into Japanese.

Resolves #211

Signed-off-by: Satomi Tsujita <satomi.t.sora@gmail.com>