### PR TITLE
Fix broken links for international workgroups (#552)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you're interested in translating Hyperledger Fabric documentation into your o
 
 [Internationalization mailing list](https://lists.hyperledger.org/g/internationalization)
 
-[Hyperledger i18n Wiki](https://wiki.hyperledger.org/display/fabric/International+groups)
+[Hyperledger i18n Wiki](https://wiki.hyperledger.org/display/I18N/International+groups)
 
 ## Hyperledger Community Links
 

--- a/docs/locale/ar/source/advice_for_writers.md
+++ b/docs/locale/ar/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/ar/source/international_languages.md
+++ b/docs/locale/ar/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/es/source/advice_for_writers.md
+++ b/docs/locale/es/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/es/source/international_languages.md
+++ b/docs/locale/es/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/fa-IR/source/advice_for_writers.md
+++ b/docs/locale/fa-IR/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/fa-IR/source/international_languages.md
+++ b/docs/locale/fa-IR/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/fr_FR/source/advice_for_writers.md
+++ b/docs/locale/fr_FR/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/fr_FR/source/international_languages.md
+++ b/docs/locale/fr_FR/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/it_IT/source/advice_for_writers.md
+++ b/docs/locale/it_IT/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/it_IT/source/international_languages.md
+++ b/docs/locale/it_IT/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/ja_JP/source/advice_for_writers.md
+++ b/docs/locale/ja_JP/source/advice_for_writers.md
@@ -53,7 +53,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group)�
 ## Join a language translation workgroup
 
 各国際言語には、参加をお勧めする友好的なワークグループがあります。 [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups) をご覧ください。
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups) をご覧ください。
 気になったワークグループが何をしているか確認し、参加してください。
 各ワークグループには、メンバーとその連絡先情報のリストがあります。
 

--- a/docs/locale/ja_JP/source/international_languages.md
+++ b/docs/locale/ja_JP/source/international_languages.md
@@ -26,7 +26,7 @@ Hyperledger Fabricのドキュメントは、多くの異なる言語に翻訳�
 
 他の翻訳者と協力することで、翻訳、メンテナンス、その言語のレポジトリの管理がより簡単になります。
 このためには、既存のワーキングループのページを参考にして、まず新しいワーキンググループを
-[国際ワーキンググループのリスト](https://wiki.hyperledger.org/display/fabric/International+groups)
+[国際ワーキンググループのリスト](https://wiki.hyperledger.org/display/I18N/International+groups)
 に追加します。
 
 

--- a/docs/locale/pt_BR/source/advice_for_writers.md
+++ b/docs/locale/pt_BR/source/advice_for_writers.md
@@ -53,7 +53,7 @@ há atas e gravações de cada sessão. Saiba mais no
 ## Junte-se a um grupo de trabalho de tradução de idiomas
 
 Cada uma das línguas internacionais tem um grupo acolhedor que você é
-encorajado a aderir. Veja a [lista de grupos de trabalho internacionais](https://wiki.hyperledger.org/display/fabric/International+groups).
+encorajado a aderir. Veja a [lista de grupos de trabalho internacionais](https://wiki.hyperledger.org/display/I18N/International+groups).
 Veja o que seu grupo de trabalho favorito está fazendo e conecte-se a eles.
 Cada grupo de trabalho possui uma lista de membros e suas informações de contato.
 

--- a/docs/locale/pt_BR/source/international_languages.md
+++ b/docs/locale/pt_BR/source/international_languages.md
@@ -49,7 +49,7 @@ está bem avançada e outros idiomas, como o português do Brasil e o malaiala,
 estão em andamento.
 
 Você pode encontrar uma lista de todos os 
-[grupos de idiomas internacionais atuais](https://wiki.hyperledger.org/display/fabric/International+groups) 
+[grupos de idiomas internacionais atuais](https://wiki.hyperledger.org/display/I18N/International+groups) 
 no wiki do Hyperledger. Esses grupos têm listas de membros ativos com os quais 
 você pode se conectar. Eles realizam reuniões regulares nas quais você pode 
 participar.
@@ -243,7 +243,7 @@ traduções de idiomas internacionais:
 
     Cada um dos idiomas internacionais possui um grupo de trabalho onde todos são
     bem-vindos e incentivados a participar. Essa é a 
-    [lista de grupos de trabalho internacionais](https://wiki.hyperledger.org/display/fabric/International+groups). 
+    [lista de grupos de trabalho internacionais](https://wiki.hyperledger.org/display/I18N/International+groups). 
     Veja o que seu grupo de trabalho favorito está fazendo e conecte-se a eles,
     cada grupo de trabalho tem uma lista de membros e suas informações de contato.
 
@@ -251,7 +251,7 @@ traduções de idiomas internacionais:
   * Crie uma página de grupo de trabalho de tradução de idiomas
 
     Se você decidiu criar uma tradução para um novo idioma, adicione um novo 
-    grupo de trabalho à [lista de grupos de trabalho internacionais](https://wiki.hyperledger.org/display/fabric/International+groups), 
+    grupo de trabalho à [lista de grupos de trabalho internacionais](https://wiki.hyperledger.org/display/I18N/International+groups), 
     usando um dos grupos existentes páginas do grupo de trabalho como um exemplo.
 
     Vale a pena documentar como o seu grupo de trabalho colaborará, reuniões, 

--- a/docs/locale/ru_RU/source/advice_for_writers.md
+++ b/docs/locale/ru_RU/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/ru_RU/source/international_languages.md
+++ b/docs/locale/ru_RU/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/ta_IN/source/advice_for_writers.md
+++ b/docs/locale/ta_IN/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/ta_IN/source/international_languages.md
+++ b/docs/locale/ta_IN/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/vi_VN/source/advice_for_writers.md
+++ b/docs/locale/vi_VN/source/advice_for_writers.md
@@ -59,7 +59,7 @@ wiki](https://wiki.hyperledger.org/display/fabric/Documentation+Working+Group).
 
 Each of the international languages has a welcoming workgroup that you are
 encouraged to join. View the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups).
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups).
 See what your favorite workgroup is doing, and get connected with them.
 Each workgroup has a list of members and their contact information.
 

--- a/docs/locale/vi_VN/source/international_languages.md
+++ b/docs/locale/vi_VN/source/international_languages.md
@@ -30,7 +30,7 @@ create a new language workgroup.
 It's much easier to translate, maintain, and manage a language repository if you
 collaborate with other translators. Start this process by adding a new workgroup
 to the [list of international
-workgroups](https://wiki.hyperledger.org/display/fabric/International+groups),
+workgroups](https://wiki.hyperledger.org/display/I18N/International+groups),
 using one of the existing workgroup pages as an exemplar.
 
 Document how your workgroup will collaborate; meetings, chat and mailing lists

--- a/docs/locale/zh_CN/source/international_languages.md
+++ b/docs/locale/zh_CN/source/international_languages.md
@@ -38,7 +38,7 @@ drwxr-xr-x  12 user  staff    384 15 May 07:40 docs
 
 虽然Hyperledger Fabric的默认语言是英语，就我们所知，它也支持其它翻译。[中文文档](https://hyperledger-fabric.readthedocs.io/zh_CN/latest/)的翻译就很好，其它语言诸如巴西葡萄牙语和马拉雅姆语翻译也在进行中。
 
-你可以在Hyperledger wiki找到所有的[当前国际化小组](https://wiki.hyperledger.org/display/fabric/International+groups)。你可以联系这些小组列出中的活跃翻译者。他们会欢迎你加入它们举行的定期会议。
+你可以在Hyperledger wiki找到所有的[当前国际化小组](https://wiki.hyperledger.org/display/I18N/International+groups)。你可以联系这些小组列出中的活跃翻译者。他们会欢迎你加入它们举行的定期会议。
 
 请遵循[这份介绍](./docs_guide.html)来向任何语言仓库贡献文档。这里有一份当前语言仓库的列表：
 
@@ -188,12 +188,12 @@ drwxr-xr-x  12 user  staff    384 15 May 07:40 docs
 
   * 加入一个语言翻译工作组
 
-    每个国际化语言都有一个工作组，欢迎和鼓励大家加入。查阅[国际化工作组列表](https://wiki.hyperledger.org/display/fabric/International+groups)。看看您最喜欢的工作组现在在做什么，并且联系他们；每个工作组都有个成员列表和他们的联系方式。
+    每个国际化语言都有一个工作组，欢迎和鼓励大家加入。查阅[国际化工作组列表](https://wiki.hyperledger.org/display/I18N/International+groups)。看看您最喜欢的工作组现在在做什么，并且联系他们；每个工作组都有个成员列表和他们的联系方式。
 
 
   * 创建一个语言翻译工作组页面
 
-    如果您决定创立一个新的语言翻译，把您的工作组加在[国际化工作组列表](https://wiki.hyperledger.org/display/fabric/International+groups)中，利用一个已有的工作组页面作为一个例子。
+    如果您决定创立一个新的语言翻译，把您的工作组加在[国际化工作组列表](https://wiki.hyperledger.org/display/I18N/International+groups)中，利用一个已有的工作组页面作为一个例子。
 
   * 使用其他Fabric机制诸如邮件列表，贡献者会议，维护者会议。阅读更多参见[这里](./contributing.html)。
 


### PR DESCRIPTION
The list of international workgroups was moved
from https://wiki.hyperledger.org/display/fabric/International+groups
to https://wiki.hyperledger.org/display/I18N/International+groups

Signed-off-by: Justin Yang <justin.yang@themedium.io>