### PR TITLE
fix typo

### DIFF
--- a/docs/locale/fa-IR/source/secured_asset_transfer/secured_private_asset_transfer_tutorial.md
+++ b/docs/locale/fa-IR/source/secured_asset_transfer/secured_private_asset_transfer_tutorial.md
@@ -91,7 +91,7 @@ The script will deploy the nodes of the network and create a single channel name
 
 You can use the test network script to deploy the secured asset transfer smart contract to the channel. Run the following command to deploy the smart contract to `mychannel`:
 ```
-./network.sh deployCC -ccn secured -ccp ../asset-transfer-secured-agreement/chaincode-go/ -ccl -go -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
+./network.sh deployCC -ccn secured -ccp ../asset-transfer-secured-agreement/chaincode-go/ -ccl go -ccep "OR('Org1MSP.peer','Org2MSP.peer')"
 ```
 
 Note that we are using the `-ccep` flag to deploy the smart contract with an endorsement policy of `"OR('Org1MSP.peer','Org2MSP.peer')"`. This allows either organization to create an asset without receiving an endorsement from the other organization.


### PR DESCRIPTION
Changed: in line 94, removed a "-" a.k.a dash from the command.

reason: "-ccl -go" causes an error "The chaincode language -go is not supported by this script. Supported chaincode languages are: go, java, javascript, and typescript. Deploying chaincode failed". 
Thus fixed command to overcome error.
