### PR TITLE
[ja_JP] Translate "logging-control.rst" into Japanese

### DIFF
--- a/docs/locale/ja_JP/source/logging-control.rst
+++ b/docs/locale/ja_JP/source/logging-control.rst
@@ -4,26 +4,21 @@ Logging Control
 Overview
 --------
 
-Logging in the ``peer`` and ``orderer`` is provided by the
-``common/flogging`` package. This package supports
+``ピア`` と ``Orderer`` のロギングには ``common/flogging`` を使用します。
+このパッケージは以下をサポートします。
 
--  Logging control based on the severity of the message
--  Logging control based on the software *logger* generating the message
--  Different pretty-printing options based on the severity of the
-   message
+- メッセージの重要度に応じたロギング制御
+- メッセージを生成するソフトウェア *ロガー (logger)* に基づくロギング制御
+- メッセージの重要度によって異なるプリティプリント (整形表示) オプション
 
-All logs are currently directed to ``stderr``. Global and logger-level
-control of logging by severity is provided for both users and developers.
-There are currently no formalized rules for the types of information
-provided at each severity level. When submitting bug reports, developers
-may want to see full logs down to the DEBUG level.
+現在、すべてのログは ``標準エラー`` に送られます。
+グローバルおよびロガーレベルでの重要度によるロギングの制御はユーザーと開発者の両方に提供されます。
+現在のところ、各重要度レベルで提供される情報の種類に関する正式なルールはありません。
+バグレポートを送信するとき、開発者は DEBUG レベルまでの完全なログを見たいと思うかもしれません。
 
-In pretty-printed logs the logging level is indicated both by color and
-by a four-character code, e.g, "ERRO" for ERROR, "DEBU" for DEBUG, etc. In
-the logging context a *logger* is an arbitrary name (string) given by
-developers to groups of related messages. In the pretty-printed example
-below, the loggers ``ledgermgmt``, ``kvledger``, and ``peer`` are
-generating logs.
+整形表示されたログでは、ロギングレベルは色と4文字のコード (例: ERRORは「ERRO」、DEBUGは「DEBU」など) で示されます。
+ロギングの文脈では、 *logger* は開発者が関連するメッセージのグループに与える任意の名前 (文字列) である。
+以下の例では、複数の logger ``ledgermgmt``, ``kvledger``, ``peer`` がログを生成しています。
 
 ::
 
@@ -34,86 +29,77 @@ generating logs.
    2018-11-01 15:32:38.357 UTC [peer] func1 -> INFO 006 Auto-detected peer address: 172.24.0.3:7051
    2018-11-01 15:32:38.357 UTC [peer] func1 -> INFO 007 Returning peer0.org1.example.com:7051
 
-An arbitrary number of loggers can be created at runtime, therefore there is
-no "master list" of loggers, and logging control constructs can not check
-whether logging loggers actually do or will exist.
+ランタイムに任意の数の logger を作成することができるため、logger の「マスターリスト」は存在せず、
+ロギング制御構造はロギングする logger が実際に存在するかを確認できません。
 
 Logging specification
 ---------------------
 
-The logging levels of the ``peer`` and ``orderer`` commands are controlled
-by a logging specification, which is set via the ``FABRIC_LOGGING_SPEC``
-environment variable.
+``peer`` と ``orderer`` コマンドのログレベルは、環境変数 ``FABRIC_LOGGING_SPEC`` で設定されるロギング仕様で制御されます。
 
-The full logging level specification is of the form
+完全なロギングレベルの指定は次のような形式です。
 
 ::
 
     [<logger>[,<logger>...]=]<level>[:[<logger>[,<logger>...]=]<level>...]
 
-Logging severity levels are specified using case-insensitive strings
-chosen from
+ロギングの重要度レベルは、以下に示す大文字と小文字を区別しない文字列を使用して指定します。
 
 ::
 
    FATAL | PANIC | ERROR | WARNING | INFO | DEBUG
 
-
-A logging level by itself is taken as the overall default. Otherwise,
-overrides for individual or groups of loggers can be specified using the
+ロギングレベルはそれ自体が全体的なデフォルトとして扱われます。
+あるいは、以下の構文を使用して、logger の個々またはグループに対する上書き指定ができます。
 
 ::
 
     <logger>[,<logger>...]=<level>
 
-syntax. Examples of specifications:
+この仕様の一例は以下の通りです:
 
 ::
 
-    info                                        - Set default to INFO
-    warning:msp,gossip=warning:chaincode=info   - Default WARNING; Override for msp, gossip, and chaincode
-    chaincode=info:msp,gossip=warning:warning   - Same as above
+    info                                        - デフォルトをINFOに設定
+    warning:msp,gossip=warning:chaincode=info   - デフォルトはWARNING、msp, gossip, chaincodeは上書き
+    chaincode=info:msp,gossip=warning:warning   - 同上
 
-.. note:: Logging specification terms are separated by a colon. If a term does not include a specific logger, for example `info:` then it is applied as the default log level
-   across all loggers on the component. The string `info:dockercontroller,endorser,chaincode,chaincode.platform=debug` sets
-   the default log level to `INFO` for all loggers and then the `dockercontroller`, `endorser`, `chaincode`, and
-   `chaincode.platform` loggers are set to `DEBUG`. The order of the terms does not matter. In the examples above,
-   the second and third options produce the same result although the order of the terms is reversed.
+.. note:: ロギング仕様の項目はコロンで区切られます。もし、ある項目が特定の logger を含んでいない場合 (例えば `info:`)、その項目はコンポーネント上のすべての logger のデフォルトのログレベルとして適用されます。
+   文字列 `info:dockercontroller,endorser,chaincode,chaincode.platform=debug` は、すべての logger のデフォルトのログレベルを `INFO` に設定し、
+   さらに logger `dockercontroller`, `endorser`, `chaincode` と `chaincode.platform` を `DEBUG` に設定します。
+   項目の順序は関係ありません。上の例では、2番目と3番目のオプションは順序が逆でも同じ結果になります。
 
 Logging format
 --------------
 
-The logging format of the ``peer`` and ``orderer`` commands is controlled
-via the ``FABRIC_LOGGING_FORMAT`` environment variable. This can be set to
-a format string, such as the default
+``peer`` および ``orderer`` コマンドのロギングフォーマットは、 ``FABRIC_LOGGING_FORMAT`` 環境変数を介して制御されます。
+これはフォーマット文字列を設定することができます。例えばデフォルトは以下の通りで、人間が読みやすい形式でコンソールにログを出力します。
 
 ::
 
    "%{color}%{time:2006-01-02 15:04:05.000 MST} [%{module}] %{shortfunc} -> %{level:.4s} %{id:03x}%{color:reset} %{message}"
 
-to print the logs in a human-readable console format. It can be also set to
-``json`` to output logs in JSON format.
+環境変数に ``json`` を設定することでJSON形式でログを出力することが可能です。
 
 
 Chaincode
 ---------
 
-**Chaincode logging is the responsibility of the chaincode developer.**
+**チェーンコードのロギングはチェーンコード開発者の責任です。**
 
-As independently executed programs, user-provided chaincodes may technically
-also produce output on stdout/stderr. While naturally useful for “devmode”,
-these channels are normally disabled on a production network to mitigate abuse
-from broken or malicious code. However, it is possible to enable this output
-even for peer-managed containers (e.g. “netmode”) on a per-peer basis
-via the CORE_VM_DOCKER_ATTACHSTDOUT=true configuration option.
+独立して実行されるプログラムとして、ユーザー提供のチェーンコードは
+技術的には 標準出力/標準エラーに出力を生成することができます。
+これらの出力は「devmode」では当然有用なのですが、
+一方、通常、本番ネットワークでは壊れたあるいは悪意のあるコードによる不正利用を防ぐために無効になっています。
+ただし、CORE_VM_DOCKER_ATTACHSTDOUT=true 設定オプションを使用することで、
+ピア管理コンテナ (「netmode」など) でもピアごとにこの出力を有効にすることができます。
 
-Once enabled, each chaincode will receive its own logging channel keyed by its
-container-id. Any output written to either stdout or stderr will be integrated
-with the peer’s log on a per-line basis. It is not recommended to enable this
-for production.
+有効にすると、各チェーンコードは、そのコンテナID (container-id) によってキーが設定された自身のロギングチャネルを受け取ります。
+標準出力または標準エラーに書き込まれたすべての出力は、行単位でピアのログに統合されます。
+本番環境でこの機能を有効にすることは推奨されません。
 
-Stdout and stderr not forwarded to the peer container can be viewed from the
-chaincode container using standard commands for your container platform.
+ピアコンテナに転送されない標準出力と標準エラーは、
+お使いのコンテナプラットフォームの標準コマンドを使用して、チェーンコードコンテナから表示することができます。
 
 ::
 


### PR DESCRIPTION
This patch translates ""logging-control.rst" into Japanese.

Resolves #591