### PR TITLE
[ja_JP] Translate "tutorials.rst" into Japanese

### DIFF
--- a/docs/locale/ja_JP/source/tutorials.rst
+++ b/docs/locale/ja_JP/source/tutorials.rst
@@ -1,33 +1,15 @@
 Tutorials
 =========
 
-Application developers can use the Fabric tutorials to get started building their
-own solutions. Start working with Fabric by deploying the `test network <./test_network.html>`_
-on your local machine. You can then use the steps provided by the :doc:`deploy_chaincode`
-tutorial to deploy and test your smart contracts. The :doc:`write_first_app`
-tutorial provides an introduction to how to use the APIs provided by the Fabric
-SDKs to invoke smart contracts from your client applications. For an in depth
-overview of how Fabric applications and smart contracts work together, you
-can visit the :doc:`developapps/developing_applications` topic.
+アプリケーションの開発者は、Fabricのチュートリアルを使用して、独自のソリューションの構築を始めることができます。 `test network <./test_network.html>`_ をローカルマシンにデプロイして、Fabricとの作業を開始します。その後、 :doc:`deploy_chaincode` チュートリアルで提供されている手順を使用して、スマートコントラクトをデプロイしてテストすることができます。 :doc:`write_first_app` チュートリアルは、Fabric SDKが提供するAPIを使用してクライアントアプリケーションからスマートコントラクトを呼び出す方法について情報を提供しています。Fabricアプリケーションとスマートコントラクトがどのように連携するかの詳細については、 :doc:`developapps/developing_applications` トピックをご覧ください。
 
-Network operators can use the :doc:`deploy_chaincode` tutorial and the
-:doc:`create_channel/create_channel_overview` tutorial series to learn
-important aspects of administering a running network. Both network operators and
-application developers can use the tutorials on
-`Private data <./private_data_tutorial.html>`_ and `CouchDB <./couchdb_tutorial.html>`_
-to explore important Fabric features. When you are ready to deploy Hyperledger
-Fabric in production, see the guide for :doc:`deployment_guide_overview`.
+ネットワーク運用者は、 :doc:`deploy_chaincode` チュートリアルおよび :doc:`create_channel/create_channel_overview` チュートリアルのシリーズで、実行中のネットワークを管理するための重要な側面を学習できます。ネットワーク運用者とアプリケーション開発者の両者が、 `Private data <./private_data_tutorial.html>`_ と `CouchDB <./couchdb_tutorial.html>`_ のチュートリアルを使用して、Fabricの重要な機能を調べることができます。本番にデプロイするHyperledger Fabricの準備ができたら、 :doc:`deployment_guide_overview` のガイドを参照してください。
 
-There are two tutorials for updating a channel: :doc:`config_update` and
-:doc:`updating_capabilities`, while :doc:`upgrading_your_components` shows how
-to upgrade components like peers, ordering nodes, SDKs, and more.
+:doc:`config_update` と :doc:`updating_capabilities` のチャネルを更新するための2つのチュートリアルがあります。 :doc:`upgrading_your_components` では、ピア、オーダリングノード、SDKなどのコンポーネントをアップグレードする方法について説明しています。
 
-Finally, we provide an introduction to how to write a basic smart contract,
-:doc:`chaincode4ade`.
+最後に、基本的なスマートコントラクトを書く方法 :doc:`chaincode4ade` を紹介します。
 
-.. note:: If you have questions not addressed by this documentation, or run into
-          issues with any of the tutorials, please visit the :doc:`questions`
-          page for some tips on where to find additional help.
+.. note:: このドキュメントで説明されていない質問がある場合、またはいずれかのチュートリアルで問題が発生した場合は、 :doc:`questions` ページにアクセスして、追加のヘルプを見つけるためのヒントを見つけてください。
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
This patch translates source/tutorials.rst into Japanese.

Resolves #739

Signed-off-by: Satomi Tsujita <satomi.t.sora@gmail.com>