### PR TITLE
[ja_JP] Translate "commands/peernode.md" into Japanese

### DIFF
--- a/docs/locale/ja_JP/source/commands/peernode.md
+++ b/docs/locale/ja_JP/source/commands/peernode.md
@@ -1,12 +1,11 @@
 # peer node
 
-The `peer node` command allows an administrator to start a peer node,
-reset all channels in a peer to the genesis block, or rollback a
-channel to a given block number.
+`peer node` コマンドは、管理者がピアノードを起動したり、ピア内のすべてのチャネルをジェネシスブロックにリセットしたり、
+チャネルを指定されたブロック番号にロールバックしたりすることを可能にします。
 
 ## Syntax
 
-The `peer node` command has the following subcommands:
+`peer node` コマンドには以下のサブコマンドがあります:
 
   * start
   * reset
@@ -54,14 +53,16 @@ Flags:
 
 ### peer node start example
 
-The following command:
+以下のコマンドを実行すると:
 
 ```
 peer node start --peer-chaincodedev
 ```
 
-starts a peer node in chaincode development mode. Normally chaincode containers are started
-and maintained by peer. However in chaincode development mode, chaincode is built and started by the user. This mode is useful during chaincode development phase for iterative development.
+コマンドは、ピアノードをチェーンコード開発モードで起動します。
+通常、チェーンコードコンテナはピアによって起動され管理されます。
+しかしチェーンコード開発モードでは、チェーンコードはユーザーによってビルドされ開始されます。
+このモードは、チェーンコードの開発フェーズにおいて、反復的な開発のために有用です。
 
 ### peer node reset example
 
@@ -69,16 +70,28 @@ and maintained by peer. However in chaincode development mode, chaincode is buil
 peer node reset
 ```
 
-resets all channels in the peer to the genesis block, i.e., the first block in the channel. The command also records the pre-reset height of each channel in the file system. Note that the peer process should be stopped while executing this command. If the peer process is running, this command detects that and returns an error instead of performing the reset. When the peer is started after performing the reset, the peer will fetch the blocks for each channel which were removed by the reset command (either from other peers or orderers) and commit the blocks up to the pre-reset height. Until all channels reach the pre-reset height, the peer will not endorse any transactions.
+上記のコマンドは、ピアのすべてのチャネルをジェネシスブロック、つまりチャネルの最初のブロックにリセットします。
+このコマンドは、ファイルシステム内の各チャネルのリセット前のブロックの高さも記録します。
+このコマンドを実行している間は、ピアプロセスを停止しておく必要があることに注意してください。
+ピアプロセスが実行中の場合、このコマンドはそれを検出し、リセットを実行する代わりにエラーを返します。
+リセットの実行後にピアが起動すると、ピアは、リセットコマンドによって削除された各チャネルのブロックを（他のピアまたはOrdererから）取得し、
+リセット前の高さまでブロックをコミットします。
+すべてのチャネルがリセット前の高さに達するまで、ピアはいかなるトランザクションもエンドースしません。
 
 ### peer node rollback example
 
-The following command:
+以下のコマンドを実行すると:
 
 ```
 peer node rollback -c ch1 -b 150
 ```
 
-rolls back the channel ch1 to block number 150. The command also records the pre-rolled back height of channel ch1 in the file system. Note that the peer should be stopped while executing this command. If the peer process is running, this command detects that and returns an error instead of performing the rollback. When the peer is started after performing the rollback, the peer will fetch the blocks for channel ch1 which were removed by the rollback command (either from other peers or orderers) and commit the blocks up to the pre-rolled back height. Until the channel ch1 reaches the pre-rolled back height, the peer will not endorse any transaction for any channel.
+コマンドは、チャネルch1をブロック番号150にロールバックします。
+このコマンドは、ファイルシステムにチャネルch1のロールバック前のブロックの高さを記録します。
+このコマンドを実行している間は、ピアを停止しておく必要があることに注意してください。
+ピアプロセスが実行中の場合、このコマンドはそれを検出し、ロールバックを実行する代わりにエラーを返します。
+ロールバックを実行した後にピアが起動すると、ピアはロールバックコマンドによって削除されたチャネルch1のブロックを（他のピアまたはOrdererから）取得し、
+ロールバック前の高さまでブロックをコミットします。チャネルch1がロールバック前の高さに達するまで、
+ピアはいかなるチャネルのトランザクションもエンドースしません。
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
This patch translates "commands/peernode.md" into Japanese.

Resolves #609

Signed-off-by: Tatsuya Sato <tatsuya.sato.so@hitachi.com>