### PR TITLE
[ja_JP] Translate "commands/configtxlator.md"

### DIFF
--- a/docs/locale/ja_JP/source/commands/configtxlator.md
+++ b/docs/locale/ja_JP/source/commands/configtxlator.md
@@ -1,13 +1,11 @@
 # configtxlator
 
-The `configtxlator` command allows users to translate between protobuf and JSON
-versions of fabric data structures and create config updates.  The command may
-either start a REST server to expose its functions over HTTP or may be utilized
-directly as a command line tool.
+`configtxlator` コマンドは、ユーザーがFabricのデータ構造をプロトコルバッファとJSONの間で変換し、設定の更新ファイルを作成することができるコマンドです。
+このコマンドは、RESTサーバーとしてHTTP経由で機能を受け付けることもできますし、コマンドラインツールとして直接使うこともできます。
 
 ## Syntax
 
-The `configtxlator` tool has five sub-commands, as follows:
+`configtxlator` ツールには5つの下記のサブコマンドがあります。
 
   * start
   * proto_encode
@@ -94,14 +92,13 @@ Flags:
 
 ### Decoding
 
-Decode a block named `fabric_block.pb` to JSON and print to stdout.
+`fabric_block.pb`というブロックをJSONに変換し、標準出力に表示します。
 
 ```
 configtxlator proto_decode --input fabric_block.pb --type common.Block
 ```
 
-Alternatively, after starting the REST server, the following curl command
-performs the same operation through the REST API.
+別の方法として、RESTサーバーを開始した後に、下記のcurlコマンドを実行することで、REST APIを介して同じ操作ができます。
 
 ```
 curl -X POST --data-binary @fabric_block.pb "${CONFIGTXLATOR_URL}/protolator/decode/common.Block"
@@ -109,14 +106,13 @@ curl -X POST --data-binary @fabric_block.pb "${CONFIGTXLATOR_URL}/protolator/dec
 
 ### Encoding
 
-Convert a JSON document for a policy from stdin to a file named `policy.pb`.
+標準入力で与えるポリシーのJSONファイルを変換し、`policy.pb`というファイルに出力します。
 
 ```
 configtxlator proto_encode --type common.Policy --output policy.pb
 ```
 
-Alternatively, after starting the REST server, the following curl command
-performs the same operation through the REST API.
+別の方法として、RESTサーバーを開始した後に、下記のcurlコマンドを実行することで、REST APIを介して同じ操作ができます。
 
 ```
 curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/encode/common.Policy" > policy.pb
@@ -124,14 +120,13 @@ curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/encode/co
 
 ### Pipelines
 
-Compute a config update from `original_config.pb` and `modified_config.pb` and decode it to JSON to stdout.
+`original_config.pb`から`modified_config.pb`への設定の更新差分を計算し、JSONにデコードして標準出力に表示します。
 
 ```
 configtxlator compute_update --channel_id testchan --original original_config.pb --updated modified_config.pb | configtxlator proto_decode --type common.ConfigUpdate
 ```
 
-Alternatively, after starting the REST server, the following curl commands
-perform the same operations through the REST API.
+別の方法として、RESTサーバーを開始した後に、下記のcurlコマンドを実行することで、REST APIを介して同じ操作ができます。
 
 ```
 curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@modified_config.pb" "${CONFIGTXLATOR_URL}/configtxlator/compute/update-from-configs" | curl -X POST --data-binary /dev/stdin "${CONFIGTXLATOR_URL}/protolator/decode/common.ConfigUpdate"
@@ -139,19 +134,10 @@ curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@
 
 ## Additional Notes
 
-The tool name is a portmanteau of *configtx* and *translator* and is intended to
-convey that the tool simply converts between different equivalent data
-representations. It does not generate configuration. It does not submit or
-retrieve configuration. It does not modify configuration itself, it simply
-provides some bijective operations between different views of the configtx
-format.
+このツールの名前は、 *configtx* と *translator* の混成語で、同じ内容の異なるデータ表現の間を単純変換するツールという意味を持たせる意図によるものです。このツールは、設定を生成しませんし、設定を送信することも取得することもありませんし、このツールだけでは設定の変更もしません。このツールは、configtxのフォーマットの異なる表現の間の全単射の操作を提供するだけのものです。
 
-There is no configuration file `configtxlator` nor any authentication or
-authorization facilities included for the REST server.  Because `configtxlator`
-does not have any access to data, key material, or other information which
-might be considered sensitive, there is no risk to the owner of the server in
-exposing it to other clients.  However, because the data sent by a user to
-the REST server might be confidential, the user should either trust the
-administrator of the server, run a local instance, or operate via the CLI.
+`configtxlator`には設定ファイルはありませんし、RESTサーバーには認証・認可の仕組みは含まれていません。
+`configtxlator`は、データや重要な素材、そのほかの機密となりうる情報へのアクセスを持っていないため、サーバーの所有者がこれを他のクライアントに公開することにリスクはありません。
+ただし、ユーザーがRESTサーバーに送るデータは機密のものがありうるため、ユーザーはサーバーの管理者を信頼するか、ローカルのインスタンスを立ち上げるか、CLIによって操作する必要があります。
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
This patch translates "Commands Reference >> configtxlator" into Japanese.

Resolves #611