### PR TITLE
[ja_JP] Translate "commands/cryptogen.md"

### DIFF
--- a/docs/locale/ja_JP/source/commands/configtxlator.md
+++ b/docs/locale/ja_JP/source/commands/configtxlator.md
@@ -137,7 +137,7 @@ curl -X POST -F channel=testchan -F "original=@original_config.pb" -F "updated=@
 このツールの名前は、 *configtx* と *translator* の混成語で、同じ内容の異なるデータ表現の間を単純変換するツールという意味を持たせる意図によるものです。このツールは、設定を生成しませんし、設定を送信することも取得することもありませんし、このツールだけでは設定の変更もしません。このツールは、configtxのフォーマットの異なる表現の間の全単射の操作を提供するだけのものです。
 
 `configtxlator`には設定ファイルはありませんし、RESTサーバーには認証・認可の仕組みは含まれていません。
-`configtxlator`は、データや重要な素材、そのほかの機密となりうる情報へのアクセスを持っていないため、サーバーの所有者がこれを他のクライアントに公開することにリスクはありません。
+`configtxlator`は、データや鍵マテリアル、そのほかの機密となりうる情報へのアクセスを持っていないため、サーバーの所有者がこれを他のクライアントに公開することにリスクはありません。
 ただし、ユーザーがRESTサーバーに送るデータは機密のものがありうるため、ユーザーはサーバーの管理者を信頼するか、ローカルのインスタンスを立ち上げるか、CLIによって操作する必要があります。
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/docs/locale/ja_JP/source/commands/cryptogen.md
+++ b/docs/locale/ja_JP/source/commands/cryptogen.md
@@ -1,12 +1,12 @@
 # cryptogen
 
-`cryptogen` is an utility for generating Hyperledger Fabric key material.
-It is provided as a means of preconfiguring a network for testing purposes.
-It would normally not be used in the operation of a production network.
+`cryptogen` は、Hyperledger Fabricの鍵マテリアルを生成するためのツールです。
+このツールは、テスト用途のネットワークの事前設定を行うための方法として提供されています。
+本番環境のネットワークの運用には通常は使われないでしょう。
 
 ## Syntax
 
-The ``cryptogen`` command has five subcommands, as follows:
+``cryptogen`` コマンドには、次の5つのサブコマンドがあります。
 
   * help
   * generate
@@ -92,8 +92,7 @@ Flags:
 
 ## Usage
 
-Here's an example using the different available flags on the ``cryptogen extend``
-command.
+``cryptogen extend`` コマンドで利用可能な複数のフラグを利用した例を次に示します。
 
 ```
     cryptogen extend --input="crypto-config" --config=config.yaml
@@ -101,6 +100,6 @@ command.
     org3.example.com
 ```
 
-Where config.yaml adds a new peer organization called ``org3.example.com``
+これは、config.yaml で ``org3.example.com`` という新しいピア組織を追加する場合のものです。
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
This PR translates "Commands Reference >> cryptogen" into Japanese.
It also contains a patch to fix the translation for "key material" to use the same Japanese word in "configtxlator" and "cryptogen" commands reference.

Closes #612