### PR TITLE
Update makefile and tox.ini for fix local build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ verificate-translation:
 .PHONY: docs-lang-%
 docs-lang-%: verificate-translation
 	@echo "Generating translation for $(TRANSLATION)"
-	@docker run -v $$(pwd)/docs:/docs hyperledger-fabric.jfrog.io/fabric-tox sh -c 'cd /docs/locale/$(TRANSLATION)/ && tox -e docs'
+	@docker run -v $$(pwd)/docs:/docs n42org/tox:3.4.0 sh -c 'cd /docs/locale/$(TRANSLATION)/ && tox -e docs'
 
 .PHONY: docs-linkcheck-lang-%
 docs-linkcheck-lang-%: verificate-translation

--- a/docs/locale/ja_JP/tox.ini
+++ b/docs/locale/ja_JP/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True


### PR DESCRIPTION
This patch fixes 2 files to execute local build correctly.
Currently when I execute local build, I have the following output.

```
$ make docs-lang-ja_JP
Generating translation for ja_JP
docs recreate: /docs/locale/ja_JP/.tox/docs
docs installdeps: -rrequirements.txt
ERROR: invocation failed (exit code 1), logfile: /docs/locale/ja_JP/.tox/docs/log/docs-1.log
================================== log start ===================================
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
ERROR: Could not find a version that satisfies the requirement alabaster==0.7.13 (from -r requirements.txt (line 2)) (from versions: 0.1.0, 0.2.0, 0.3.0, 0.3.1, 0.4.0, 0.4.1, 0.5.0, 0.5.1, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.7.1, 0.7.2, 0.7.3, 0.7.4, 0.7.5, 0.7.6, 0.7.7, 0.7.8, 0.7.9, 0.7.10, 0.7.11, 0.7.12)
ERROR: No matching distribution found for alabaster==0.7.13 (from -r requirements.txt (line 2))
WARNING: You are using pip version 20.2.2; however, version 20.3.4 is available.
You should consider upgrading via the '/docs/locale/ja_JP/.tox/docs/bin/python -m pip install --upgrade pip' command.
```
The essential error is that I cannot install alabaster, because python version on local build environment is 2.7.
So this patch changes pyhon version from 2.7 to 3.7.
I refer [Makefile](https://github.com/hyperledger/fabric/blob/main/Makefile) and [tox.ini](https://github.com/hyperledger/fabric/blob/main/tox.ini) in Hyperledger Fabric repository.