### PR TITLE
[zh-CN]Fix duplicate content in zh_CN/source/policies.rst

### DIFF
--- a/docs/locale/zh_CN/source/policies.rst
+++ b/docs/locale/zh_CN/source/policies.rst
@@ -210,26 +210,20 @@ component resembling a file basename is the policy name.
                             Writers
                             Admins
 
-Different components of the system will refer to these policy names. For
-instance, to call ``Deliver`` on the orderer, the signature on the
-request must satisfy the ``/Channel/Readers`` policy. However, to gossip
-a block to a peer will require that the ``/Channel/Application/Readers``
-policy be satisfied.
-
 Consider the Writers policy referred to with the ``------->`` mark in
 the above example. This policy may be referred to by the shorthand
 notation ``/Channel/Application/Writers``. Note that the elements
 resembling directory components are group names, while the last
 component resembling a file basename is the policy name.
 
-By setting these different policies, the system can be configured with
-rich access controls.
-
 Different components of the system will refer to these policy names. For
 instance, to call ``Deliver`` on the orderer, the signature on the
 request must satisfy the ``/Channel/Readers`` policy. However, to gossip
 a block to a peer will require that the ``/Channel/Application/Readers``
 policy be satisfied.
+
+By setting these different policies, the system can be configured with
+rich access controls.
 
 Constructing a SignaturePolicy
 ------------------------------


### PR DESCRIPTION
**Description:**
This pull request fixes duplicate content in the zh_CN/source/policies.rst file to ensure consistency with other language versions.

The duplicated content can be found in the policies documentation on Hyperledger Fabric at this [link](https://hyperledger-fabric.readthedocs.io/zh-cn/release-2.5/policies.html)
![image](https://github.com/hyperledger/fabric-docs-i18n/assets/35106934/9090ad3f-e93e-4765-ada5-234272a7d812)

**Changes**

- Removed the duplicated content.

- Reordered the paragraphs to match the structure in `en_US/source/policies.rst`.