### PR TITLE
Update tox.ini for fix local build error

### DIFF
--- a/docs/locale/es/tox.ini
+++ b/docs/locale/es/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/fr_FR/tox.ini
+++ b/docs/locale/fr_FR/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/it_IT/tox.ini
+++ b/docs/locale/it_IT/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/ko_KR/tox.ini
+++ b/docs/locale/ko_KR/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/ml_IN/tox.ini
+++ b/docs/locale/ml_IN/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/pt_BR/tox.ini
+++ b/docs/locale/pt_BR/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/ru_RU/tox.ini
+++ b/docs/locale/ru_RU/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/ta_IN/tox.ini
+++ b/docs/locale/ta_IN/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True

--- a/docs/locale/zh_CN/tox.ini
+++ b/docs/locale/zh_CN/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 1.6
+minversion = 3.4
 envlist =
     docs,
 skipsdist=true
@@ -10,3 +10,5 @@ commands =
     sphinx-build -b html -n -d {envtmpdir}/doctrees ./source {toxinidir}/_build/html
     echo "Generated docs available in {toxinidir}/_build/html"
 whitelist_externals = echo
+basepython=python3.7
+ignore_basepython_conflict=True


### PR DESCRIPTION
This patch fixes 9 tox.ini files to execute local build correctly except for Japanese language.
This is the same solution as #931 .