### PR TITLE
[ja_JP] Translate "performance.md" into Japanese

### DIFF
--- a/docs/locale/ja_JP/source/performance.md
+++ b/docs/locale/ja_JP/source/performance.md
@@ -1,46 +1,68 @@
 # Performance considerations
 
-Various Hyperledger Fabric component, configuration, and workflow decisions contribute to the overall performance of your network. Managing these variables, such as the number of channels, chaincode implementations, and transaction policies, can be complex with multiple participating organizations contributing their own hardware and networking infrastructures to the environment. 
+Hyperledger Fabricのコンポーネント、構成、ワークフローの決定は、ネットワークの全体的なパフォーマンスに影響します。
+チャネル数、チェーンコードの実装、トランザクションポリシーなど、これらの変数の管理は、
+複数の参加組織がそれぞれのハードウェアやネットワークインフラをネットワーク環境に提供することで、複雑になる可能性があります。
 
-This topic walks you through the considerations that can help you optimize performance for your Hyperledger Fabric network. 
+このトピックでは、Hyperledger Fabricネットワークのパフォーマンスを最適化するために役立つ考慮事項について説明します。
 
 ## Hardware considerations
 
-Each participating organization can provide hardware for hosting peer and ordering service nodes. Ordering service nodes can be provided by a single organization or by multiple organizations. Because any organization can impact the performance of the entire network (depending on factors such as transaction endorsement policies), each participating organization must provide adequate resources for network services and applications which they deploy.
+各参加組織は、ピアおよびオーダリングサービスノードをホスティングするためのハードウェアを提供することができます。
+オーダリングサービスノードは、単一の組織が提供することも、複数の組織が提供することもできます。
+どの組織もネットワーク全体のパフォーマンスに影響を与える可能性があるため（トランザクションのエンドースメントポリシーなどの要因による）、
+各参加組織は、自らがデプロイするネットワークサービスとアプリケーションのために十分なリソースを提供しなければなりません。
 
 ### Persistent storage
 
-Because a Hyperledger Fabric network performs a high volume of disk I/O, you must use the fastest disk storage that is practicable. If you are using network-attached storage, ensure that you choose the fastest IOPs available.
+Hyperledger Fabricネットワークは大量のディスクI/Oを実行するため、可能な限り高速なディスクストレージを使用する必要があります。
+ネットワーク接続ストレージを使用する場合は、利用可能な最速のIOPSを選択するようにしてください。
 
 ### Network connectivity
 
-A Hyperledger Fabric network is highly-distributed across multiple nodes and is typically hosted on multiple clusters, in different cloud environments, and even across legal and geographic boundaries. Therefore, high-speed network connectivity between nodes is vital, and a minimum of 1 Gbps should be deployed between all nodes and organizations.
+Hyperledger Fabricネットワークは複数のノードに高度に分散され、
+一般的に複数のクラスタ、異なるクラウド環境、さらには法的・地理的境界を越えてホストされます。
+そのため、ノード間の高速ネットワーク接続は不可欠であり、すべてのノードと組織間で最低1Gbpsを確保する必要があります。
 
 ### CPU and memory
 
-The final hardware consideration is the amount of CPU and Memory to allocate to peer and ordering service nodes, and for any CouchDB state databases used for peer nodes. These allocations affect network performance and even node stability, so you must continuously monitor CPU, Memory, Disk Space, and Disk and Network I/O to ensure that you are well within the limits of your allocated resources. Do not wait to approach maximum utilization before increasing node resources - a threshold of  70%-80% usage is a general guideline for maximum workload.
+ハードウェアに関する最後の考慮事項は、ピアとオーダリングサービスノード、およびピアノードが使用するCouchDBステートデータベースに割り当てるCPUとメモリの量です。
+これらの割り当ては、ネットワークパフォーマンス、さらにはノードの安定性に影響を与えるため、CPU、メモリ、ディスク容量、およびディスクとネットワークI/Oを継続的に監視し、
+割り当てられたリソースの制限内にあることを確認する必要があります。
+最大使用率に近づくまで、ノードのリソースを増やすのを待ってはいけません。最大作業負荷の一般的なガイドラインは、閾値の70%～80%程度の使用率です。
 
-Network performance generally scales with CPU allocated to peer nodes, so providing each peer (and CouchDB if used) with the maximum CPU capacity is recommended. For orderer nodes, a general guideline is 1 CPU with 2 GB of Memory.
+ネットワーク性能は、一般的にピアノードに割り当てられたCPUでスケールするので、各ピア（および使用されている場合はCouchDB）に最大CPU容量を提供することをお勧めします。
+ordererノードについては、一般的なガイドラインは、2 GBのメモリと1 CPUです。
 
-As the amount of state data grows, database storage performance can slow down, especially when using CouchDB as the state database. Therefore, you should plan to add more compute resources to your environment over time, while continuously monitoring your network components and adjusting to any thresholds being exceeded.
+ステートデータの量が増加すると、特にステートデータベースとしてCouchDBを使用する場合、データベースストレージのパフォーマンスが低下する可能性があります。
+したがって、ネットワークコンポーネントを継続的に監視し、閾値を超えた場合は調整を行うとともに、時間の経過とともに環境にコンピュートリソースを追加する計画を立てる必要があります。
 
 ## Peer considerations
 
-Peer considerations for overall network performance include the number of active channels and node configuration properties. The default peer and orderer configurations, from the peer **core.yaml** and orderer **orderer.yaml** files, are referenced below.
+ネットワーク全体のパフォーマンスに関するピアの考慮事項には、アクティブチャネル数とノード構成プロパティが含まれます。ピアの**core.yaml**ファイルとordererの**orderer.yaml**ファイルにおける、
+デフォルトのピアおよびOrdererの構成を以下に示します。
 
 ### Number of peers
 
-The more peers that each organization deploys the better the network should perform, because transaction endorsement requests can be load-balanced across each  organization's peers. However, gateway peers select peers for transaction endorsement based on their current block height, so distribution amongst peers eligible for endorsement is not easily predicted. Work done by a single gateway peer can be predictably reduced by selecting a gateway peer from among multiple gateway peers to submit or evaluate a transaction based on a defined policy such as round robin. This selection of a gateway peer could be done via a load balancer, coded into the client application, or by the grpc library used for gateway selection. (Note: these scenarios have **NOT** been formally benchmarked for any performance gains.)
+各組織がデプロイするピア数が多ければ多いほど、各組織のピア間でトランザクションのエンドース要求を負荷分散できるため、ネットワークの性能は向上するはずです。
+しかし、ゲートウェイピアは現在のブロックの高さに基づいてトランザクションのエンドースを行うピアを選択するため、ピア間でのエンドースの分散状況は容易に予測できません。
+ラウンドロビンなど、事前に定義されたポリシーに基づいて、トランザクションを提出または評価するゲートウェイピアを複数のゲートウェイピアの中から選択することで、
+単一のゲートウェイピアによって行われる作業を予測可能な形で減らすことができます。
+このゲートウェイピアの選択は、ロードバランサー、クライアントアプリケーションにてコード化されたもの、またはゲートウェイ選択時に使用されるgrpcライブラリによって実現できます。
+(注：これらのシナリオによる性能向上の正式なベンチマークは **されていません** )。
 
 ### Number of channels per peer
 
-If a peer has ample CPU and is participating in only one channel, it is not possible to drive the peer beyond 65-70% CPU because of how the peer does serialization and locking internally. If a peer is participating in multiple channels, the peer will consume the available resource as it increases parallelism in block processing.
+ピアに十分なCPUがあり、1つのチャネルにしか参加していない場合、ピアが内部でどのようにシリアライズとロックを行っていたとしても、ピアのCPUは65～70%以上になることはありません。
+ピアが複数のチャネルに参加している場合、ピアはブロック処理の並列性を高めるため、利用可能なリソースを消費します。
 
-In general, ensure that there is a CPU core available for each channel that is running at maximum load. As a general guideline, if the load in each channel is not highly-correlated (i.e., channels are not all contending for resources simultaneously), the number of channels can exceed the number of CPU cores.
+一般に、最大負荷で動作している各チャネルに対し、利用可能なCPUコアが少なくとも1つあることを確認してください。
+一般的なガイドラインとして、各チャネルの負荷が高度に競合していない場合（つまり、全チャネルがリソースを同時に使用しない場合）、チャネルの数がCPUコアの数を超えても問題ありません。
 
 ### Total query limit
 
-A peer limits the total number of records a range or JSON (rich) query will return, in order to avoid larger than expected result sets that could slow down a peer. This limit is configured in the peer's **core.yaml** file:
+ピアは、ピアの速度を低下させる可能性のある予想よりも大きな結果セットを避けるために、
+レコードの範囲またはJSON（リッチ）クエリが返すレコードの総数を制限します。この制限は、ピアの **core.yaml** ファイルで設定します:
 
 ```yaml
 
@@ -50,11 +72,12 @@ ledger:
     totalQueryLimit: 100000
 ```
 
-The Hyperledger Fabric total query limit default is 100000, as set in the sample **core.yaml** file and test docker images. You can increase this default value if necessary, but you should also consider alternative designs that do not require the higher number of query scans.
+サンプルの**core.yaml**ファイルとテスト用のdockerイメージで設定されているように、Hyperledger Fabricのクエリ制限の合計はデフォルトで100000です。
+必要に応じてこのデフォルト値を増やすこともできますが、より多くのクエリスキャンを必要としない代替設計も検討する必要があります。
 
 ### Concurrency limits
 
-Each peer node has limits to ensure it is not overwhelmed by excessive concurrent client requests:
+各ピアノードは、クライアントからの過剰な同時リクエストを受けないよう、制限を設けています:
 
 ```yaml
 peer:
@@ -73,11 +96,12 @@ peer:
             gatewayService: 500
 ```
 
-The Peer Gateway Service, first released in v2.4 of Hyperledger Fabric, introduced the `gatewayService` limit with a default of 500. However, this default can restrict network TPS, so you may need to increase this value to allow more concurrent requests.
+Hyperledger Fabric v2.4で初めてリリースされたPeer Gateway Serviceは、デフォルト500の`gatewayService`制限を導入しました。
+しかし、このデフォルト値はネットワークのTPSを制限する可能性があるため、より多くの同時リクエストを許可するためにこの値を増やす必要があるかもしれません。
 
 ### CouchDB cache setting
 
-If you are using CouchDB and have a large number of keys being read repeatedly (not via queries), you may choose to increase the peer's CouchDB cache to avoid database lookups:
+CouchDBを使用しており、（クエリを介してではなく）繰り返し読み込まれるキーの数が多い場合は、データベースのルックアップを回避するためにピアのCouchDBキャッシュを増やすことを選択できます:
 
 ```yaml
 
@@ -92,15 +116,22 @@ state:
 
 ## Orderer considerations
 
-The ordering service uses Raft consensus to cut blocks. Factors such as the number of orderers participating in consensus and block cutting parameters will affect overall network performance, as described below.
+オーダリングサービスは、Raftコンセンサスを使用してブロックを生成します。
+コンセンサスに参加するordererの数やブロック生成のパラメータなどの要因は、以下に説明するように、ネットワーク全体のパフォーマンスに影響を与えます。
 
 ### Number of orderers
 
-The number of ordering service nodes will impact performance because all orderers contribute to Raft consensus. Using five ordering service nodes will provide two orderer crash fault tolerance (a required majority of three remain available) and is a good starting point. Additional ordering service nodes may reduce network performance. If a single set of ordering service nodes becomes a network bottleneck, you can try deploying a unique set of ordering service nodes for each channel.
+すべてのordererがRaftのコンセンサスに貢献するため、オーダリングサービスノードの数はパフォーマンスに影響します。
+5つのオーダリングサービスノードを使用することで、2つのordererのクラッシュに対する障害耐性を提供することができ
+（過半数を超える3つのordererが利用可能な状態を維持する必要がある）、良い出発点となります。
+オーダリングサービスノードを追加すると、ネットワークのパフォーマンスが低下する可能性があります。
+オーダリングサービスノードがネットワークのボトルネックになる場合は、各チャネルに固有のオーダリングサービスノードを配置することができます。
 
 ### SendBufferSize
 
-Prior to Hyperledger Fabric v2.5, the default SendBufferSize of each orderer node was set to 10, which causes a bottleneck. In Fabric v2.5, this default was changed to 100, which provides improved throughput. The SendBufferSize parameter is configured in **orderer.yaml**:
+Hyperledger Fabric v2.5以前では、各ordererノードのデフォルトのSendBufferSizeは10に設定されており、ボトルネックの原因となっていました。
+Fabric v2.5では、このデフォルトが100に変更され、スループットが向上しました。
+SendBufferSizeパラメータは**orderer.yaml**で設定します:
 
 ```yaml
 General:
@@ -113,9 +144,13 @@ General:
 
 ### Block cutting parameters in channel configuration
 
-Channel configuration settings can also affect performance of the ordering service. Increasing the channel block size and timeout parameters can increase throughput but can also increase latency. As described below, you can configure the ordering service for increased transactions per block and longer block cutting times to test the performance results. 
+チャネルのコンフィギュレーション設定は、オーダリングサービスのパフォーマンスにも影響します。
+チャネルのブロックサイズとタイムアウトパラメータを増加させると、スループットが向上しますが、レイテンシも増加します。
+以下に説明するように、ブロックあたりのトランザクションを増やし、ブロック生成間隔を長くするようにオーダリングサービスを構成して、パフォーマンス結果をテストすることができます。
 
-Three orderer batch size parameters - Max Message Count, Absolute Max Bytes, and Preferred Max Bytes - perform block cutting based on the specified block size and maximum number of transactions. These parameters are set when you create or update a channel configuration. If you use **configtxgen** and **configtx.yaml** as a starting point for creating channels, the following section in **configtx.yaml** applies:
+ordererのバッチサイズに関する3つのパラメータ（Max Message Count、Absolute Max Bytes、Preferred Max Bytes）により指定されたブロックサイズと最大トランザクション数に基づいてブロック生成が実行されます。
+これらのパラメータは、チャネルコンフィギュレーションを作成または更新するときに設定されます。
+チャネル作成の開始点として**configtxgen**と**configtx.yaml**を使用する場合、**configtx.yaml**の以下のセクションが適用されます:
 
 ```yaml
 Orderer: &OrdererDefaults
@@ -159,124 +194,182 @@ Orderer: &OrdererDefaults
 
 #### Batch timeout
 
-Set the BatchTimeout value to the amount of time, in seconds, to wait after the first transaction arrives before cutting the block. If you set this value too low, you risk preventing the batches from filling to your preferred size. Setting this value too high, however, can cause the orderer to wait for blocks and overall performance and latency to degrade. A general guideline is to set the value of BatchTimeout to be at a minimum the max message count divided by the maximum transactions per second.
+BatchTimeout値には、最初のトランザクションが到着してからブロックを生成するまでに待つ時間を秒単位で設定します。
+この値を低く設定しすぎると、希望するサイズまでバッチが充填されなくなる危険性があります。
+一方、この値を高く設定しすぎると、ordererがブロックを待つことになり、全体的なパフォーマンスとレイテンシーが低下する可能性があります。
+一般的なガイドラインは、BatchTimeoutの値を、最低でも（最大メッセージ数÷1秒あたりの最大トランザクション数）に設定することです。
 
 #### Max message count
 
-Set the Max message count value to the maximum number of transactions to include in a single block.
+Max message count値には、1つのブロックに含めるトランザクションの最大数を設定します。
 
 #### Absolute max bytes
 
-Set the Absolute max bytes value to the largest block size in bytes for the ordering service to cut. No transaction can be larger than the value of Absolute max bytes. This setting can typically be 2-10 times larger than the Preferred max bytes value. Note: The maximum recommended size is 49 MB, based on the headroom needed for the default grpc size limit of 100 MB.
+Absolute max bytes値には、オーダリングサービスが生成する最大のブロックサイズをバイト単位で設定します。
+Absolute max bytesの値より大きなトランザクションは生成されません。
+この設定は、Preferred max bytes値の2～10倍にすることが一般的です。
+注：推奨される最大サイズは、デフォルトのgrpcサイズ制限である100MBに基づく上限値である49MBです。
 
 #### Preferred max bytes
 
-Set the Preferred max bytes value to your ideal block size in bytes, which must be less than the Absolute max bytes. A minimum transaction size, one that contains no endorsements, is around 1 KB. If you add 1 KB per required endorsement, a typical transaction size is approximately 3-4 KB. Therefore, it is recommended to set the value of Preferred max bytes to be close to the Max message count multiplied by the expected average transaction size. At run time, whenever possible, blocks will not exceed this size. If a transaction arrives that causes the block to exceed the Absolute max bytes size, the block will be cut and the transaction included in a new block. The new block will be cut with the single transaction ONLY, which also cannot exceed the Absolute max bytes.
+Preferred max bytes値には、理想的なブロックサイズをバイト単位で設定します。
+最小のトランザクションサイズ（エンドースを含まないもの）は約1KBです。必要なエンドース1件につき1KBを追加すると、典型的なトランザクション・サイズは約3～4KBになります。
+したがって、Preferred max bytesの値は、Max message countに平均トランザクションサイズの予想値を乗じた値に近い値を設定することが推奨されます。
+トランザクション実行時、可能な限り、ブロックはこのサイズを超えません。ブロックがAbsolute max bytes値を超えるようなトランザクションが到着した場合、ブロックは生成され、
+トランザクションは新しいブロックに含まれます。新しいブロックは単一のトランザクションのみで生成され、これもAbsolute max bytes値を超えることはありません。
 
 ## Application considerations
 
-When designing your application architecture, various choices can affect the overall performance of both the application and the network. These application considerations are described below.
+アプリケーションアーキテクチャを設計する際、さまざまな選択がアプリケーションとネットワークの両方の全体的なパフォーマンスに影響を与える可能性があります。
+これらのアプリケーションの考慮事項については、以下で説明します。
 
 ### Avoid CouchDB for high-throughput applications
 
-CouchDB performance is noticably slower than embedded LevelDB, sometimes by a factor of 2x slower. The only additional capability that a CouchDB state database provides is JSON (rich) queries, as stated in the [Fabric state database documentation](./deploypeer/peerplan.html#state-database). In addition, to ensure the integrity of the state data you must never allow direct access to CouchDB data (for instance via Fauxton UI). 
+CouchDBのパフォーマンスは組み込みのLevelDBよりも明らかに遅く、場合によっては2倍遅くなります。
+[Fabric state database documentation](./deploypeer/peerplan.html#state-database) に記載されている通り、CouchDBステートデータベースが提供する唯一の追加機能は、JSON（リッチ）クエリです。
+また、ステートデータの整合性を確保するために、CouchDBデータへの直接アクセス（たとえば、Fauxton UI 経由）を許可しないでください。
 
-CouchDB as a state database has other limitations which reduce overall network performance and require additional hardware resource (and cost). For one, JSON queries are not re-executed at validation time, so Fabric does not offer built-in protection from phantom reads. Such protection is provided, however, by range queries. (Your application must be designed to tolerate phantom reads when using JSON queries, such as when records are added to state between the times of chaincode execution and block validation). You should therefore consider using range queries based on additional keys for high-throughput applications, rather than using CouchDB with JSON queries.
+ステートデータベースとしてのCouchDB には、全体的なネットワークパフォーマンスを低下させ、追加のハードウェアリソース（およびコスト）を必要とするという別の制約もあります。
+さらに、JSONクエリは検証時に再実行されないため、Fabricにはファントムリードに対する組み込みの保護機能がありません。
+一方、範囲クエリではそのような保護機能が提供されます
+（JSONクエリを使用する場合、チェーンコードの実行とブロックの検証の間に状態にレコードが追加されるなどのファントムリードを許容するようにアプリケーションを設計する必要があります）。
+したがって、高スループットアプリケーションでは、CouchDBにJSONクエリを使用するのではなく、追加のキーに基づく範囲クエリを使用することを検討する必要があります。
 
-Alternatively, consider using an off-chain store to support queries, as seen in the [Off-chain sample](https://github.com/hyperledger/Fabric-samples/tree/main/off_chain_data). Using an off-chain store for queries gives you much more control over the data, and query transactions do not affect Hyperledger Fabric peer and network performance. It also enables you to use a fit-for-purpose data store for off-chain storage, such as an SQL database or analytics service more aligned with your query needs.
+あるいは、[Off-chain sample](https://github.com/hyperledger/Fabric-samples/tree/main/off_chain_data) に示されているように、
+クエリをサポートするためにオフチェーン ストアの使用を検討してください。
+クエリにオフチェーン ストアを使用すると、データをより細かく制御でき、クエリトランザクションはHyperledger Fabricピアとネットワークのパフォーマンスに影響を与えません。
+また、ユーザによるクエリのニーズにより適合したSQLデータベースや分析サービスなど、オフチェーンストレージに適したデータストアを使用することもできます。
 
-CouchDB performance also degrades more than LevelDB does as the amount of state data increases, requiring you to provide adequate resources for CouchDB instances for the life of the application.
+CouchDBのパフォーマンスは、ステートデータの量が増加するにつれてLevelDBよりも低下するため、アプリケーションの存続期間中、CouchDBインスタンスに十分なリソースを提供する必要があります。
 
 ### General chaincode query considerations
 
-Avoid writing chaincode queries that could be unbounded in the amount of data returned, or bounded but returning an amount of data large enough to cause a transaction to time out. It is against Fabric best practices for transactions to run for a long time, so ensure that your queries are optimized to limit the amount of data returned. If JSON queries are used, ensure they are indexed. See [Good practice for queries](./couchdb_as_state_database.html#good-practices-for-queries) for guidance on JSON queries.
+返されるデータの量が無制限になる可能性があるチェーンコードクエリや、返されるデータの量が制限されていてもトランザクションがタイムアウトするほど大量のデータを返すチェーンコードクエリを記述することは避けてください。
+トランザクションを長時間実行することは Fabric のベストプラクティスに反するため、返されるデータの量を制限するようにクエリを最適化してください。
+JSONクエリを使用する場合は、インデックスが付けられていることを確認してください。JSONクエリのガイダンスについては、
+[Good practice for queries](./couchdb_as_state_database.html#good-practices-for-queries) を参照してください。
 
 ### Use the Peer Gateway Service
 
-The Peer Gateway Service (new in v2.4) and new Fabric-Gateway client SDKs offer substantial enhancements over the legacy Go, Java, and Node SDKs. The Peer Gateway Service provides much improved throughput, and more capabilities and reduced complexity to client applications. For example, the service automatically (attempts to) collect the endorsements required to satisfy not only the chaincode endorsement policy, but also any state-based endorsement policies included with transaction simulation (which is not possible using the legacy SDKs).
+ピアゲートウェイサービス（v2.4の新機能）と新しいFabric-Gateway client SDK は、従来のGo、Java、およびNode SDKを大幅に強化しています。
+ピアゲートウェイサービスでは、スループットが大幅に向上し、クライアントアプリケーションの機能が増え、複雑さが軽減されます。
+例えばこのサービスは、チェーンコードエンドースメントポリシーだけでなく、
+トランザクションシミュレーションに含まれるステートベースのエンドースメントポリシーを満たすために必要なエンドースメントを自動的に収集（試行）します（これは従来のSDKでは不可能です）。
 
-The Peer Gateway Service also reduces the number of network connections a client needs to maintain to submit a transaction. Using the legacy SDKs, clients may need to connect to multiple peer and orderer nodes across organizations. By contrast, the Peer Gateway Service service enables an application to connect to a single trusted peer, which then collects endorsements from other peer and orderer nodes and submits the transaction on behalf of the client application. Your application can target multiple trusted peers for high concurrency and redundancy, when necessary.
+ピアゲートウェイサービスでは、クライアントがトランザクションを送信するために維持する必要があるネットワーク接続の数も削減されます。
+従来のSDKを使用すると、クライアントは組織全体の複数のピアノードとordererノードに接続する必要がある場合があります。
+これに対し、ピアゲートウェイサービスを使用すると、アプリケーションは単一の信頼できるピアに接続でき、そのピアは他のピアノードとordererノードからエンドースメントを収集し、
+クライアントアプリケーションに代わってトランザクションを送信します。
+必要に応じて、アプリケーションは複数の信頼できるピアをターゲットにでき、高い同時実行性と冗長性を実現できます。
 
-Changing your application development environment from the legacy SDKs to the new Peer Gateway Service also reduces client CPU and memory resource requirements, with a modest increase in peer resource requirements.
+アプリケーション開発環境を従来のSDKから新しいピアゲートウェイ サービスに変更すると、クライアントのCPUとメモリのリソース要件も削減されますが、ピアリソース要件は若干増加します。
 
-See the [Sample gateway application](https://github.com/hyperledger/Fabric-samples/blob/main/full-stack-asset-transfer-guide/docs/ApplicationDev/01-FabricGateway.md) for more details about the Peer Gateway Service.
+ピアゲートウェイサービスの詳細については、[Sample gateway application](https://github.com/hyperledger/Fabric-samples/blob/main/full-stack-asset-transfer-guide/docs/ApplicationDev/01-FabricGateway.md) を参照してください。
 
 ### Payload size
 
-The amount of data that is submitted to a transaction, along with the amount of data written to keys in a transaction will affect the application performance. Note that the payload size includes more than just the data. It includes structures required by Fabric plus client and endorsing peer signatures.
+トランザクションとして送信されるデータの量と、トランザクション内のキーに書き込まれるデータの量は、アプリケーションのパフォーマンスに影響します。
+ペイロードサイズには、データだけが含まれるのではないことに注意してください。Fabricに必要なデータ構造に加えて、クライアントとエンドーシングピアの署名も含まれます。
 
-Suffice to say large payload sizes are an anti-pattern in any blockchain solution. Consider storing large data off-chain and storing a hash of the data on-chain.
+言うまでもなく、大きなペイロードサイズは、どのブロックチェーンソリューションでもアンチパターンです。
+大きなデータをオフチェーンで保存し、データのハッシュをオンチェーンで保存することを検討してください。
 
 ### Chaincode language
 
-Go chaincode has shown the best performance in Hyperledger Fabric environments, followed by Node chaincode. Java chaincode performance is the least performant of the three, and is not recommended for high-throughput applications.
+GoチェーンコードはHyperledger Fabric環境で最高のパフォーマンスを示し、次にNodeチェーンコードが続きます。Javaチェーンコードのパフォーマンスは3つの中で最も低く、高スループットのアプリケーションには推奨されません。
 
 ### Node chaincode
 
-Node is an asynchronous runtime implementation that utilizes only a single thread to execute code. Node does run background threads for activities such as garbage collection, but it may not improve performance to allocate more than two vCPUs (generally equivalent to the number of concurrent threads which can be executed) to a Node chaincode (for example on Kubernetes which is limited to available resources). It is worth monitoring performance of Node chaincode to see how much vCPU it uses. Node chaincode is self-limiting and not unbounded, though you could also assign resource restrictions to Node chaincode processes. 
+Nodeは、コードを実行するために単一のスレッドのみを使用する非同期ランタイム実装です。
+Nodeはガベージ コレクションなどのアクティビティのためにバックグラウンド スレッドを実行しますが、Nodeチェーンコードに2つ以上のvCPU（通常、実行可能な同時スレッドの数に相当）
+を割り当ててもパフォーマンスが向上しない可能性があります（使用可能なリソースに制限があるKubernetes使用時など）。
+Nodeチェーンコードのパフォーマンスを監視して、vCPUがどれだけ使用されているかを確認することは価値があります。
+Nodeチェーンコードは自己制限型であり、無制限ではありませんが、Nodeチェーンコードプロセスにリソース制限を割り当てることもできます。
 
-Prior to Node v12, a Node process was limited to 1.5 GB of Memory by default, which to increase for running Node chaincode required passing a parameter to the Node executable. You should not be running chaincode processes on any version earlier than Node v12, and Hyperledger Fabric v2.5 mandates using Node v16, or later. Various parameters can be provided when launching Node chaincode, but few if any scenarios would require overriding the default values for Node v12 and later.
+Node v12より前では、Nodeプロセスのメモリ使用量はデフォルトで1.5 GBに制限されていました。
+Nodeチェーンコードを実行するためにメモリを増やすには、Node実行ファイルにパラメータを渡す必要がありました。
+Node v12より前のバージョンではチェーンコードプロセスを実行するべきではなく、Hyperledger Fabric v2.5ではNode v16以降の使用が必須です。
+Nodeチェーンコードを起動する際は様々なパラメータを指定できますが、Node v12以降ではデフォルト値を上書きする必要があるケースはほとんどありません。
 
 ### Go chaincode
 
-The Golang runtime implementation is ideal for concurrency. It is capable of using all CPUs available to it, and thus, is only limited by the resources allocated to the chaincode process. No tuning is required.
+Golangランタイム実装は並行処理に最適です。利用可能なすべてのCPUを使用できるため、チェーンコードプロセスに割り当てられたリソースによってのみ制限されます。チューニングは必要ありません。
 
 ### Chaincode processes and channels
 
-Hyperledger Fabric reuses chaincode processes across channels if the chaincode ID and versions match. For example, if a peer is joined to two channels with the same chaincode ID and version deployed, the peer will only interact with one chaincode process for both channels. This can place more load on the chaincode process than expected, especially for Node chaincode which is self-limiting. In this case, you can either use Go chaincode or deploy Node chaincode to each channel using different IDs or version numbers to ensure a distinct chaincode process per channel.
+Hyperledger Fabric は、チェーンコードIDとバージョンが一致する場合、チャネル間でチェーンコードプロセスを再利用します。
+例えば、同じチェーンコードIDとバージョンがデプロイされた2つのチャネルにピアが参加している場合、ピアは両方のチャネルにおいて1つのチェーンコードプロセスのみと対話します。
+これにより、特に自己制限的なNodeチェーンコードの場合、チェーンコードプロセスに予想以上の負荷がかかる可能性があります。
+この場合、Goチェーンコードを使用してください。あるいは、異なるIDまたはバージョン番号を使用して各チャネルにNodeチェーンコードをデプロイすることで、
+チャネルごとに異なるチェーンコードプロセスを確保することができます。
 
 ### Endorsement policies
 
-For a transaction to be committed as valid, it must contain the signatures required to satisfy the chaincode endorsement policy and any state-based endorsement policies. The Peer Gateway Service (Fabric v2.4 and later) will only send requests to enough peers to satisfy the collection of policies (and will try other peers if the preferred peers are not available). Endorsement policies therefore affect performance because they dictate how many peers (and their signatures) are required for a transaction to be committed as valid.
+トランザクションが有効なものとしてコミットされるためには、チェーンコードのエンドースメントポリシーとステートベースのエンドースメントポリシーを満たすために必要な署名が含まれている必要があります。
+ピアゲートウェイサービス（Fabric v2.4以降）は、ポリシーを満たすのに十分なピアにのみリクエストを送信します（優先されるピアが利用できない場合は他のピアを試します）。
+エンドースメントポリシーは、トランザクションが有効としてコミットされるために必要なピアの数（およびその署名）を規定するため、パフォーマンスに影響します。
 
 ### Private Data Collections (PDCs) vs World State
 
-In general, the decision of whether to use Private Data Collections (PDCs) is an application architecture decision and not a performance decision. However, it should be noted that, for example, using a PDC to store an asset rather than using the world state results in approximately half the TPS.
+一般的に、プライベートデータコレクション(PDC)を使用するかどうかは、パフォーマンスの観点ではなく、アプリケーションアーキテクチャの観点により決まります。
+ただし、たとえば、ワールドステートを使用するのではなくPDCを使用してアセットを保存すると、TPSが約半分になることに注意してください。
 
 ### Single or multiple channel architecture
 
-When designing your application, consider whether a single channel or multiple channels can be utilized. If data silos are not a problem for a given scenario, the application could use multiple channel architecture to improve performance (because multiple channels enable using more of the peer resource).
+アプリケーションを設計するときは、単一のチャネルを利用するか、複数のチャネルを利用できるかを検討してください。
+与えられたシナリオでデータサイロが問題にならない場合は、アプリケーションで複数のチャネルからなるアーキテクチャを使用することでパフォーマンスを向上させることができます
+（複数のチャネルを使用すると、より多くのピアリソースを使用できるため）。
 
 ## CouchDB considerations
 
-As mentioned, CouchDB is not recommended for high-throughput applications, and all limitations should be considered, as described below.
+前述のように、CouchDBは高スループットのアプリケーションには推奨されておらず、以下に説明するすべての制限を考慮する必要があります。
 
 ### Resources
 
-Ensure monitoring of resources used by CouchDB instances, because as the size of the state database increases, CouchDB consumes more resources.
+ステートデータベースのサイズが大きくなるにつれて、CouchDBが消費するリソースも増えるため、CouchDBインスタンスが使用するリソースを必ず監視してください。
 
 ### CouchDB cache
 
-When using an external CouchDB state database, read delays during the endorsement and validation transaction phases have shown to be a performance bottleneck. In Fabric v2.x, the peer cache replaces many of these expensive lookups with fast local cache reads.
+外部の CouchDBステートデータベースを使用する場合、トランザクションのエンドースおよび検証フェーズでの参照遅延がパフォーマンスのボトルネックになることが判明しています。
+Fabric v2.xでは、ピアキャッシュによって、これらのコストのかかる検索の多くが高速なローカルキャッシュ参照に置き換えられます。
 
-The cache will not improve performance of JSON queries.
+キャッシュによってJSONクエリのパフォーマンスが向上することはありません。
 
-See the **CouchDB Cache setting** details above (in **Peer Considerations**) for information on configuring the cache.
+キャッシュの構成については、上記の **CouchDB Cache setting** の詳細 (**Peer Considerations**内) を参照してください。
 
 ### Indexes
 
-Include CouchDB indexes with any chaincode that utilizes CouchDB JSON queries. Test queries to ensure that indexes are utilized, and avoid queries that cannot use indexes. For example, use of the query operators $or, $in, $regex result in full data scans. See details in [Hyperledger Fabric Good Practices For Queries](./couchdb_as_state_database.html#good-practices-for-queries).
+CouchDB JSON クエリを利用するチェーンコードには、CouchDBインデックスを含めてください。
+クエリをテストしてインデックスが利用されていることを確認し、インデックスを使用できないクエリは避けてください。
+例えば、クエリ演算子 $or、$in、$regex を使用すると、完全なデータ スキャンが実行されます。
+詳細については、[Hyperledger Fabric Good Practices For Queries](./couchdb_as_state_database.html#good-practices-for-queries) を参照してください。
 
-Optimize your queries, because complex queries will take more time even with indexing. Ensure that your queries result in a bounded set of data. Hyperledger Fabric may also limit the total number of results returned.
+複雑なクエリはインデックスを使用しても時間がかかるため、クエリを最適化してください。
+クエリの結果が制限されたデータセットになるようにしてください。Hyperledger Fabricによって、返される結果の総数が制限される場合もあります。
 
-You can check the peer and CouchDB logs to see how long queries are taking, and whether any query was unable to use an index from a warning log entry stating the query "should be indexed".
+ピアとCouchDBのログをチェックすることで、クエリにかかる時間や、クエリが「インデックスを作成すべき」というwarningログエントリからインデックスを使用できなかったクエリがあるかどうかを確認できます。
 
-If queries are taking a long time, increasing the CPU/Memory available to CouchDB or using faster storage may improve their performance.
+クエリに時間がかかる場合は、CouchDBで使用できるCPU/メモリを増やすか、より高速なストレージを使用すると、パフォーマンスが向上する可能性があります。
 
-Check CouchDB logs for warnings such as "The number of documents examined is high in proportion to the number of results returned. Consider adding a more specific index to improve this." These messages indicate that your indexes could be improved because a high number of documents are being scanned.
+CouchDBログで、"The number of documents examined is high in proportion to the number of results returned. Consider adding a more specific index to improve this."などの警告がないか確認してください。
+これらのメッセージは、スキャンされているドキュメントの数が多いため、インデックスを改善できる余地があることを示しています。
 
 ### Bulk update
 
-Hyperledger Fabric uses bulk update calls to CouchDB to improve CouchDB performance. A bulk update is done at the block level, so including more transactions in a block can improve throughput. However, increasing the time before a block is cut to include more transactions will also have an impact on latency.
+Hyperledger Fabric は、CouchDB のパフォーマンスを向上させるために、CouchDBへの一括更新(Bulk update)呼び出しを使用します。
+一括更新はブロックレベルで実行されるため、ブロックに多くのトランザクションを含めるとスループットが向上します。
+ただし、より多くのトランザクションを含めるためにブロックが生成されるまでの時間を長くすると、レイテンシにも影響します。
 
 ## HSM
 
-Using HSMs in a Fabric network will have an impact on performance. It is not possible to quantify the impact, but variables such as HSM performance and its network connection will impact the overall performance of the network.
+FabricネットワークでHSMを使用すると、パフォーマンスに影響します。影響を定量化することはできませんが、HSMのパフォーマンスやネットワーク接続などの変数は、ネットワーク全体のパフォーマンスに影響します。
 
-If you have configured Peers, Orderers, and Clients to use an HSM, then anything that requires signing will utilize the HSM, including creation of blocks by orderers, endorsements and block events by peers, and all client requests.
+ピア、orderer、クライアントがHSMを使用するように構成した場合、ordererによるブロックの作成、ピアによるエンドースメントとブロックイベント、各クライアントによるリクエストなど、署名を必要とするものはすべてHSMを利用します。
 
-Note that HSMs are NOT involved in the verification of signatures, which is done by each node.
+なお、HSMは各ノードによって実行される署名の検証には関与しないことに注意してください。
 
 ## Other performance considerations
 
-Sending single transactions periodically has a latency correlating to the block cutting parameters. For example, if you send a transaction of 100 Bytes with a  BatchTimeout of 2 seconds, then the time from transaction submission to commitment will be just over 2 seconds. However, this is not a true benchmark of your Fabric network performance, which should be obtained by submitting multiple transactions simultaneously.
+単一のトランザクションを定期的に送信すると、ブロック生成パラメータと相関するレイテンシが発生します。
+たとえば、BatchTimeoutを2秒に設定して 100バイトのトランザクションを送信すると、トランザクションの送信からコミットまでの時間は2秒強になります。
+ただし、これはFabricネットワークパフォーマンスの正しいベンチマークではありません。実際のベンチマークは、複数のトランザクションを同時に送信することで取得する必要があります。


### PR DESCRIPTION
This patch translates "performance.md" into Japanese.
This patch is related to the issue https://github.com/hyperledger/fabric-docs-i18n/issues/912.